### PR TITLE
Fix WinAPI feature for Windows build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ page_size = "0.4.1"
 thread-priority = "0.1.0"
 
 [target.'cfg(windows)'.dependencies]
-winapi = { version = "0.3", features = ["std","fileapi","securitybaseapi"] }
+winapi = { version = "0.3", features = ["std","fileapi","securitybaseapi","errhandlingapi"] }
 
 [build-dependencies]
 cc = "1.0"


### PR DESCRIPTION
## Summary
- include the `errhandlingapi` feature when building for Windows

## Testing
- `cargo check`
- `cargo check --target x86_64-pc-windows-gnu`

------
https://chatgpt.com/codex/tasks/task_e_6843ea0b5858832a9cdd0d6ca0b31d62